### PR TITLE
Change cudss_set to cudss_update in README examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ norm(r_gpu)
 # In-place LU
 d_gpu = rand(T, n) |> CuVector
 A_gpu = A_gpu + Diagonal(d_gpu)
-cudss_set(solver, A_gpu)
+cudss_update(solver, A_gpu)
 
 c_cpu = rand(T, n)
 c_gpu = CuVector(c_cpu)
@@ -110,7 +110,7 @@ norm(R_gpu)
 # In-place LDLᵀ
 d_gpu = rand(R, n) |> CuVector
 A_gpu = A_gpu + Diagonal(d_gpu)
-cudss_set(solver, A_gpu)
+cudss_update(solver, A_gpu)
 
 C_cpu = rand(T, n, p)
 C_gpu = CuMatrix(C_cpu)
@@ -155,7 +155,7 @@ norm(R_gpu)
 # In-place LLᴴ
 d_gpu = rand(R, n) |> CuVector
 A_gpu = A_gpu + Diagonal(d_gpu)
-cudss_set(solver, A_gpu)
+cudss_update(solver, A_gpu)
 
 C_cpu = rand(T, n, p)
 C_gpu = CuMatrix(C_cpu)


### PR DESCRIPTION
When I copy paste the current examples I get the error, and changing cudss_set to cudss_update fixes this error.

```
julia> include("cudss_test.jl")
ERROR: LoadError: MethodError: no method matching cudss_set(::CudssSolver{Float64, Int32}, ::CuSparseMatrixCSR{Float64, Int32})
The function `cudss_set` exists, but no method is defined for this combination of argument types.

Closest candidates are:
  cudss_set(::CUDSS.AbstractCudssSolver, ::String, ::Any)
   @ CUDSS ~/.julia/packages/CUDSS/K3Ejh/src/interfaces.jl:277

Stacktrace:
 [1] top-level scope
   @ ~/git/qoco-gpu-benchmarks/cudss_test.jl:31
 [2] include(fname::String)
   @ Main ./sysimg.jl:38
 [3] top-level scope
   @ REPL[4]:1

```