### PR TITLE
compat with CUDA@6.0.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,28 +5,32 @@ version = "0.6.7"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+CUDACore = "bd0ed864-bdfe-4181-a5ed-ce625a5fdea2"
 CUDA_Runtime_Discovery = "1af6417a-86b4-443c-805f-a4643ffb695f"
 CUDSS_jll = "4889d778-9329-5762-9fec-0578a5d30366"
 GPUToolbox = "096a3bc2-3ced-46d0-87f4-dd12716f4bfc"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+cuSPARSE = "b26da814-b3bc-49ef-b0ee-c816305aa060"
 
 [compat]
 CEnum = "0.5"
-CUDA = "5.4.0"
-CUDSS_jll = "0.7.1"
+CUDACore = "6.0.0"
 CUDA_Runtime_Discovery = "1.0.0"
+CUDSS_jll = "0.7.1"
 GPUToolbox = "0.3, 1"
 LinearAlgebra = "1.10"
 Random = "1.10"
 SparseArrays = "1.10"
 Test = "1.10"
+cuSOLVER = "6.0.0"
+cuSPARSE = "6.0.0"
 julia = "1.10"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+cuSOLVER = "887afef0-6a32-4de5-add4-7827692ba8fc"
 
 [targets]
-test = ["Random", "Test"]
+test = ["Random", "Test", "cuSOLVER"]

--- a/src/CUDSS.jl
+++ b/src/CUDSS.jl
@@ -1,25 +1,25 @@
 module CUDSS
 
-using CUDA, CUDA.CUSPARSE, CUDA.CUBLAS
+using CUDACore, cuSPARSE
 using GPUToolbox
 using CUDSS_jll
 using LinearAlgebra
 using SparseArrays
 
-if CUDA.local_toolkit
+if CUDACore.local_toolkit
     using CUDA_Runtime_Discovery
 else
     import CUDSS_jll
 end
 
 function __init__()
-  if CUDA.functional()
+  if CUDACore.functional()
     global libcudss
     global CUDSS_INSTALLATION
     if haskey(ENV, "JULIA_CUDSS_LIBRARY_PATH") && Sys.islinux()
       libcudss = joinpath(ENV["JULIA_CUDSS_LIBRARY_PATH"], "libcudss.so")
       CUDSS_INSTALLATION = "CUSTOM"
-    elseif CUDA.local_toolkit
+    elseif CUDACore.local_toolkit
       dirs = CUDA_Runtime_Discovery.find_toolkit()
       path = CUDA_Runtime_Discovery.get_library(dirs, "cudss"; optional=true)
       (path === nothing) && error("cuDSS is not available on your system (looked in $(join(dirs, ", "))).")
@@ -39,8 +39,7 @@ function __init__()
   end
 end
 
-import CUDA: libraryPropertyType, cudaDataType, initialize_context, retry_reclaim, CUstream, unsafe_free!
-import CUDA.APIUtils: HandleCache
+using CUDACore: libraryPropertyType, cudaDataType, initialize_context, retry_reclaim, CUstream, unsafe_free!, HandleCache
 import LinearAlgebra: lu, lu!, ldlt, ldlt!, cholesky, cholesky!, ldiv!, BlasFloat, BlasReal, checksquare, Factorization
 import Base: \
 

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -526,7 +526,7 @@ function cudss(phase::String, solver::CudssSolver{T}, X::CudssMatrix{T}, B::Cuds
   (phase == "refactorization") && cudss_set(solver, "info", 0)
   cudss_phase = convert(cudssPhase_t, phase)
   cudssExecute(solver.data.handle, cudss_phase, solver.config, solver.data, solver.matrix, X, B)
-  !asynchronous && CUDA.synchronize()
+  !asynchronous && CUDACore.synchronize()
   if (phase == "factorization") && solver.fresh_factorization
     solver.fresh_factorization = false
   end
@@ -551,7 +551,7 @@ function cudss(phase::String, solver::CudssBatchedSolver{T}, X::CudssBatchedMatr
   (phase == "refactorization") && cudss_set(solver, "info", 0)
   cudss_phase = convert(cudssPhase_t, phase)
   cudssExecute(solver.data.handle, cudss_phase, solver.config, solver.data, solver.matrix, X, B)
-  !asynchronous && CUDA.synchronize()
+  !asynchronous && CUDACore.synchronize()
   if (phase == "factorization") && solver.fresh_factorization
     solver.fresh_factorization = false
   end

--- a/src/management.jl
+++ b/src/management.jl
@@ -18,9 +18,9 @@ function cudssGetProperty(property::libraryPropertyType)
   value_ref[]
 end
 
-version() = VersionNumber(cudssGetProperty(CUDA.MAJOR_VERSION),
-                          cudssGetProperty(CUDA.MINOR_VERSION),
-                          cudssGetProperty(CUDA.PATCH_LEVEL))
+version() = VersionNumber(cudssGetProperty(CUDACore.MAJOR_VERSION),
+                          cudssGetProperty(CUDACore.MINOR_VERSION),
+                          cudssGetProperty(CUDACore.PATCH_LEVEL))
 
 ## handles
 
@@ -38,7 +38,7 @@ end
 const idle_handles = HandleCache{CuContext,cudssHandle_t}(handle_ctor, handle_dtor)
 
 function handle()
-    cuda = CUDA.active_state()
+    cuda = CUDACore.active_state()
 
     # every task maintains library state per device
     LibraryState = @NamedTuple{handle::cudssHandle_t, stream::CuStream}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,7 @@
 using Test, Random
-using CUDA, CUDA.CUSPARSE, CUDA.CUSOLVER
+using CUDACore
+using cuSOLVER
+using cuSPARSE
 using CUDSS
 using SparseArrays
 using LinearAlgebra


### PR DESCRIPTION
This PR moves from CUDA -> CUDACore with cuSPARSE and cuSOLVER as actual subpackages.

While technically nonbreaking with respect to the CUDSS interface, I would suggest releasing it as a breaking release to avoid compat problems, for example with

https://github.com/SciML/LinearSolve.jl/blob/4cb5ed52e6fff6928fd9ab05cca43bb1945dc744/ext/LinearSolveCUDSSExt.jl#L6