### PR TITLE
Implement compatibility to CUDA v6

### DIFF
--- a/.github/workflows/Aqua.yml
+++ b/.github/workflows/Aqua.yml
@@ -15,6 +15,6 @@ jobs:
           version: '1'
       - name: Aqua.jl
         run: julia --color=yes -e 'using Pkg; Pkg.add("Aqua"); Pkg.add("CUDA"); Pkg.develop(path=".");
-                                   using Aqua, CUDA.CUSPARSE, CUDSS; Aqua.test_all(CUDSS, piracies=false, ambiguities=false, stale_deps=false);
+                                   using Aqua, cuSPARSE, CUDSS; Aqua.test_all(CUDSS, piracies=false, ambiguities=false, stale_deps=false);
                                    Aqua.test_stale_deps(CUDSS; ignore=[:CUDA_Runtime_Discovery]);
                                    Aqua.test_ambiguities(CUDSS); Aqua.test_piracies(CUDSS; treat_as_own=[CuSparseMatrixCSR])'

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "julia.environmentPath": "/home/alberto/.julia/dev/CUDSS"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "julia.environmentPath": "/home/alberto/.julia/dev/CUDSS"
-}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CUDSS"
 uuid = "45b445bb-4962-46a0-9369-b4df9d0f772e"
-authors = ["Alexis Montoison <amontoison@anl.gov>"]
 version = "0.6.7"
+authors = ["Alexis Montoison <amontoison@anl.gov>"]
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -11,17 +11,23 @@ CUDSS_jll = "4889d778-9329-5762-9fec-0578a5d30366"
 GPUToolbox = "096a3bc2-3ced-46d0-87f4-dd12716f4bfc"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+cuBLAS = "182d3088-87b7-4494-8cad-fc6afaa545bc"
+cuSOLVER = "887afef0-6a32-4de5-add4-7827692ba8fc"
+cuSPARSE = "b26da814-b3bc-49ef-b0ee-c816305aa060"
 
 [compat]
 CEnum = "0.5"
-CUDA = "5.4.0"
+CUDA = "6"
+CUDA_Runtime_Discovery = "1"
 CUDSS_jll = "0.7.1"
-CUDA_Runtime_Discovery = "1.0.0"
 GPUToolbox = "0.3, 1"
 LinearAlgebra = "1.10"
 Random = "1.10"
 SparseArrays = "1.10"
 Test = "1.10"
+cuBLAS = "6"
+cuSOLVER = "6"
+cuSPARSE = "6"
 julia = "1.10"
 
 [extras]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This ensures efficient solving of sparse linear systems on GPUs.
 ### Example 1: Sparse unsymmetric linear system with one right-hand side
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 
@@ -80,7 +80,7 @@ norm(r_gpu)
 ### Example 2: Sparse symmetric linear system with multiple right-hand sides
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 
@@ -125,7 +125,7 @@ norm(R_gpu)
 ### Example 3: Sparse hermitian positive definite linear system with multiple right-hand sides
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,6 +1,6 @@
 using Documenter, CUDSS
 using LinearAlgebra
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 
 makedocs(
   modules = [CUDSS],

--- a/docs/src/cudss.md
+++ b/docs/src/cudss.md
@@ -9,7 +9,7 @@ Both the factorization and solve phases can be efficiently repeated as long as t
 ## LU
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 
@@ -50,7 +50,7 @@ norm(r_gpu)
 ## LDLᵀ and LDLᴴ
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 
@@ -95,7 +95,7 @@ norm(R_gpu)
 ## LLᵀ and LLᴴ
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 

--- a/docs/src/generic.md
+++ b/docs/src/generic.md
@@ -16,7 +16,7 @@ F = cholesky(H)
 ```
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using LinearAlgebra
 using SparseArrays
@@ -68,7 +68,7 @@ F = ldlt(S)
 ```
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using LinearAlgebra
 using SparseArrays
@@ -112,7 +112,7 @@ LinearAlgebra.lu!(solver::CudssSolver{T,INT}, A::CuSparseMatrixCSR{T,INT}) where
 ```
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using LinearAlgebra
 using SparseArrays

--- a/docs/src/nonuniform_batch.md
+++ b/docs/src/nonuniform_batch.md
@@ -6,7 +6,7 @@
 ## Batch LU
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 
@@ -60,7 +60,7 @@ norm.(batch_r_gpu)
 ## Batch LDLᵀ and LDLᴴ
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 
@@ -122,7 +122,7 @@ norm.(batch_R_gpu)
 ## Batch LLᵀ and LLᴴ
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 

--- a/docs/src/options.md
+++ b/docs/src/options.md
@@ -1,7 +1,7 @@
 ## Iterative refinement
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using LinearAlgebra
 using SparseArrays
@@ -34,7 +34,7 @@ norm(R_gpu)
 ## User permutation
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using LinearAlgebra
 using SparseArrays
@@ -67,7 +67,7 @@ norm(r_gpu)
 ## Hybrid memory mode
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using LinearAlgebra
 using SparseArrays
@@ -106,7 +106,7 @@ norm(r_gpu)
 ## Selecting matrices in a uniform batch
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 

--- a/docs/src/schur_complement.md
+++ b/docs/src/schur_complement.md
@@ -12,7 +12,7 @@
 ## Schur complement -- LU
 
 ```julia
-using CUDA, CUDA.CUSPARSE, CUDA.CUSOLVER
+using CUDA, cuSPARSE, cuSOLVER
 using CUDSS
 using LinearAlgebra
 using SparseArrays
@@ -117,7 +117,7 @@ x1_gpu = b_gpu[1:n-ns]
 ## Schur complement -- LDLᵀ and LDLᴴ
 
 ```julia
-using CUDA, CUDA.CUSPARSE, CUDA.CUSOLVER
+using CUDA, cuSPARSE, cuSOLVER
 using CUDSS
 using LinearAlgebra
 using SparseArrays
@@ -227,7 +227,7 @@ x2_gpu = b_gpu[ns+1:n]
 ## Schur complement -- LLᵀ and LLᴴ
 
 ```julia
-using CUDA, CUDA.CUSPARSE, CUDA.CUSOLVER
+using CUDA, cuSPARSE, cuSOLVER
 using CUDSS
 using LinearAlgebra
 using SparseArrays

--- a/docs/src/uniform_batch.md
+++ b/docs/src/uniform_batch.md
@@ -19,7 +19,7 @@ This is supported provided that the batch index is the last dimension, and apply
 ## Batch LU -- cuDSS API
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 
@@ -126,7 +126,7 @@ rλ_gpu
 ## Batch LU -- generic API
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using LinearAlgebra
 using SparseArrays
@@ -201,7 +201,7 @@ rλ_gpu
 ## Batch LDLᵀ and LDLᴴ -- cuDSS API
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 
@@ -328,7 +328,7 @@ Rs_gpu
 ## Batch LDLᵀ and LDLᴴ -- generic API
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using LinearAlgebra
 using SparseArrays
@@ -419,7 +419,7 @@ Rs_gpu
 ## Batch LLᵀ and LLᴴ -- cuDSS API
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using SparseArrays, LinearAlgebra
 
@@ -522,7 +522,7 @@ rs_gpu
 ## Batch LLᵀ and LLᴴ -- generic API
 
 ```julia
-using CUDA, CUDA.CUSPARSE
+using CUDA, cuSPARSE
 using CUDSS
 using LinearAlgebra
 using SparseArrays

--- a/src/CUDSS.jl
+++ b/src/CUDSS.jl
@@ -1,12 +1,12 @@
 module CUDSS
 
-using CUDA, CUDA.CUSPARSE, CUDA.CUBLAS
+using CUDA, cuSPARSE, cuBLAS
 using GPUToolbox
 using CUDSS_jll
 using LinearAlgebra
 using SparseArrays
 
-if CUDA.local_toolkit
+if CUDACore.local_toolkit
     using CUDA_Runtime_Discovery
 else
     import CUDSS_jll
@@ -19,7 +19,7 @@ function __init__()
     if haskey(ENV, "JULIA_CUDSS_LIBRARY_PATH") && Sys.islinux()
       libcudss = joinpath(ENV["JULIA_CUDSS_LIBRARY_PATH"], "libcudss.so")
       CUDSS_INSTALLATION = "CUSTOM"
-    elseif CUDA.local_toolkit
+    elseif CUDACore.local_toolkit
       dirs = CUDA_Runtime_Discovery.find_toolkit()
       path = CUDA_Runtime_Discovery.get_library(dirs, "cudss"; optional=true)
       (path === nothing) && error("cuDSS is not available on your system (looked in $(join(dirs, ", "))).")
@@ -39,8 +39,7 @@ function __init__()
   end
 end
 
-import CUDA: libraryPropertyType, cudaDataType, initialize_context, retry_reclaim, CUstream, unsafe_free!
-import CUDA.APIUtils: HandleCache
+import CUDA.CUDACore: libraryPropertyType, cudaDataType, initialize_context, retry_reclaim, CUstream, unsafe_free!, HandleCache
 import LinearAlgebra: lu, lu!, ldlt, ldlt!, cholesky, cholesky!, ldiv!, BlasFloat, BlasReal, checksquare, Factorization
 import Base: \
 

--- a/src/management.jl
+++ b/src/management.jl
@@ -18,9 +18,9 @@ function cudssGetProperty(property::libraryPropertyType)
   value_ref[]
 end
 
-version() = VersionNumber(cudssGetProperty(CUDA.MAJOR_VERSION),
-                          cudssGetProperty(CUDA.MINOR_VERSION),
-                          cudssGetProperty(CUDA.PATCH_LEVEL))
+version() = VersionNumber(cudssGetProperty(CUDACore.MAJOR_VERSION),
+                          cudssGetProperty(CUDACore.MINOR_VERSION),
+                          cudssGetProperty(CUDACore.PATCH_LEVEL))
 
 ## handles
 
@@ -38,7 +38,7 @@ end
 const idle_handles = HandleCache{CuContext,cudssHandle_t}(handle_ctor, handle_dtor)
 
 function handle()
-    cuda = CUDA.active_state()
+    cuda = CUDACore.active_state()
 
     # every task maintains library state per device
     LibraryState = @NamedTuple{handle::cudssHandle_t, stream::CuStream}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 using Test, Random
-using CUDA, CUDA.CUSPARSE, CUDA.CUSOLVER
+using CUDA, cuSPARSE, cuSOLVER
 using CUDSS
 using SparseArrays
 using LinearAlgebra


### PR DESCRIPTION
This PR introduces the compatibility to CUDA.jl v6. There are no breaking changes in CUDA.jl, it is just a restructure of the subpackages, so I have removed the compat to CUDA.jl v5.x.

Fixes #142