### PR TITLE
Root user arrays in matrix descriptors; warn on inertia under matching

### DIFF
--- a/src/helpers.jl
+++ b/src/helpers.jl
@@ -42,12 +42,18 @@ mutable struct CudssMatrix{T,INT} <: AbstractCudssMatrix{T,INT}
     nrows::Int64
     ncols::Int64
     nz::Int64
+    # GC roots for the Julia arrays whose device pointers were handed to cuDSS.
+    # cuDSS only stores the raw pointers, so without keeping the arrays alive here
+    # they can be collected while the descriptor (and any pending async phase) still
+    # references them -- segfaults / EXECUTION_FAILED that masquerade as library bugs.
+    # `refs` is refreshed by `cudss_update` whenever the underlying pointers change.
+    refs::Any
 
     function CudssMatrix(::Type{T}, n::Integer; nbatch::Integer=1) where T <: BlasFloat
         nz = n * nbatch
         matrix_ref = Ref{cudssMatrix_t}()
         cudssMatrixCreateDn(matrix_ref, n, 1, n, CU_NULL, T, 'C')
-        obj = new{T,Cint}(T, Cint, matrix_ref[], nbatch, n, 1, nz)
+        obj = new{T,Cint}(T, Cint, matrix_ref[], nbatch, n, 1, nz, nothing)
         finalizer(cudssMatrixDestroy, obj)
         obj
     end
@@ -57,10 +63,10 @@ mutable struct CudssMatrix{T,INT} <: AbstractCudssMatrix{T,INT}
         matrix_ref = Ref{cudssMatrix_t}()
         if transposed
             cudssMatrixCreateDn(matrix_ref, n, m, m, CU_NULL, T, 'R')
-            obj = new{T,Cint}(T, Cint, matrix_ref[], nbatch, n, m, nz)
+            obj = new{T,Cint}(T, Cint, matrix_ref[], nbatch, n, m, nz, nothing)
         else
             cudssMatrixCreateDn(matrix_ref, m, n, m, CU_NULL, T, 'C')
-            obj = new{T,Cint}(T, Cint, matrix_ref[], nbatch, m, n, nz)
+            obj = new{T,Cint}(T, Cint, matrix_ref[], nbatch, m, n, nz, nothing)
         end
         finalizer(cudssMatrixDestroy, obj)
         obj
@@ -70,7 +76,7 @@ mutable struct CudssMatrix{T,INT} <: AbstractCudssMatrix{T,INT}
         m = length(b)
         matrix_ref = Ref{cudssMatrix_t}()
         cudssMatrixCreateDn(matrix_ref, m, 1, m, b, T, 'C')
-        obj = new{T,Cint}(T, Cint, matrix_ref[], 1, m, 1, m)
+        obj = new{T,Cint}(T, Cint, matrix_ref[], 1, m, 1, m, b)
         finalizer(cudssMatrixDestroy, obj)
         obj
     end
@@ -81,10 +87,10 @@ mutable struct CudssMatrix{T,INT} <: AbstractCudssMatrix{T,INT}
         matrix_ref = Ref{cudssMatrix_t}()
         if transposed
             cudssMatrixCreateDn(matrix_ref, n, m, m, B, T, 'R')
-            obj = new{T,Cint}(T, Cint, matrix_ref[], 1, n, m, nz)
+            obj = new{T,Cint}(T, Cint, matrix_ref[], 1, n, m, nz, B)
         else
             cudssMatrixCreateDn(matrix_ref, m, n, m, B, T, 'C')
-            obj = new{T,Cint}(T, Cint, matrix_ref[], 1, m, n, nz)
+            obj = new{T,Cint}(T, Cint, matrix_ref[], 1, m, n, nz, B)
         end
         finalizer(cudssMatrixDestroy, obj)
         obj
@@ -99,7 +105,7 @@ mutable struct CudssMatrix{T,INT} <: AbstractCudssMatrix{T,INT}
         cudssMatrixCreateCsr(matrix_ref, n, n, nz_batch, rowPtr, CU_NULL,
                              colVal, nzVal, INT, INT, T, structure,
                              view, index)
-        obj = new{T,INT}(T, INT, matrix_ref[], nbatch, n, n, nz_total)
+        obj = new{T,INT}(T, INT, matrix_ref[], nbatch, n, n, nz_total, (rowPtr, colVal, nzVal))
         finalizer(cudssMatrixDestroy, obj)
         obj
     end
@@ -111,7 +117,7 @@ mutable struct CudssMatrix{T,INT} <: AbstractCudssMatrix{T,INT}
         cudssMatrixCreateCsr(matrix_ref, n, n, nz_batch, rowPtr, CU_NULL,
                              colVal, nzVal, INT, INT, T, structure,
                              view, index)
-        obj = new{T,INT}(T, INT, matrix_ref[], nbatch, n, n, nz_batch * nbatch)
+        obj = new{T,INT}(T, INT, matrix_ref[], nbatch, n, n, nz_batch * nbatch, (rowPtr, colVal, nzVal))
         finalizer(cudssMatrixDestroy, obj)
         obj
     end
@@ -158,6 +164,10 @@ mutable struct CudssBatchedMatrix{T,INT,M} <: AbstractCudssMatrix{T,INT}
     ncols::Vector{INT}
     nnzA::Vector{INT}
     Mptrs::M
+    # GC roots for the per-batch source arrays. `Mptrs` is a device array of raw
+    # pointers into them, so the batch (and its element arrays) must be kept alive
+    # here for as long as this descriptor is; see the note on `CudssMatrix.refs`.
+    refs::Any
 
     function CudssBatchedMatrix(b::Vector{<:CuVector{T}}) where T <: BlasFloat
         matrix_ref = Ref{cudssMatrix_t}()
@@ -168,7 +178,7 @@ mutable struct CudssBatchedMatrix{T,INT,M} <: AbstractCudssMatrix{T,INT}
         Mptrs = unsafe_cudss_batch(b)
         M = typeof(Mptrs)
         cudssMatrixCreateBatchDn(matrix_ref, nbatch, nrows, ncols, ld, Mptrs, Cint, T, 'C')
-        obj = new{T,Cint,M}(T, Cint, matrix_ref[], nbatch, nrows, ncols, Cint[], Mptrs)
+        obj = new{T,Cint,M}(T, Cint, matrix_ref[], nbatch, nrows, ncols, Cint[], Mptrs, b)
         finalizer(cudssBatchedMatrixDestroy, obj)
         obj
     end
@@ -186,7 +196,7 @@ mutable struct CudssBatchedMatrix{T,INT,M} <: AbstractCudssMatrix{T,INT}
         else
             cudssMatrixCreateBatchDn(matrix_ref, nbatch, nrows, ncols, ld, Mptrs, Cint, T, 'C')
         end
-        obj = new{T,Cint,M}(T, Cint, matrix_ref[], nbatch, nrows, ncols, Cint[], Mptrs)
+        obj = new{T,Cint,M}(T, Cint, matrix_ref[], nbatch, nrows, ncols, Cint[], Mptrs, B)
         finalizer(cudssBatchedMatrixDestroy, obj)
         obj
     end
@@ -203,7 +213,7 @@ mutable struct CudssBatchedMatrix{T,INT,M} <: AbstractCudssMatrix{T,INT}
                                   view, index)
         Mptrs = (rowPtrs, colVals, nzVals)
         M = typeof(Mptrs)
-        obj = new{T,INT,M}(T, INT, matrix_ref[], nbatch, nrows, ncols, nnzA, Mptrs)
+        obj = new{T,INT,M}(T, INT, matrix_ref[], nbatch, nrows, ncols, nnzA, Mptrs, A)
         finalizer(cudssBatchedMatrixDestroy, obj)
         obj
     end

--- a/src/interfaces.jl
+++ b/src/interfaces.jl
@@ -179,19 +179,23 @@ function cudss_update end
 
 function cudss_update(matrix::CudssMatrix{T}, b::CuVector{T}) where T <: BlasFloat
   cudssMatrixSetValues(matrix, b)
+  matrix.refs = b
 end
 
 function cudss_update(matrix::CudssMatrix{T}, B::CuMatrix{T}) where T <: BlasFloat
   cudssMatrixSetValues(matrix, B)
+  matrix.refs = B
 end
 
 function cudss_update(matrix::CudssMatrix{T}, tensor::CuArray{T}) where T <: BlasFloat
   @assert matrix.nbatch > 1
   cudssMatrixSetValues(matrix, tensor)
+  matrix.refs = tensor
 end
 
 function cudss_update(matrix::CudssMatrix{T,INT}, A::CuSparseMatrixCSR{T,INT}) where {T <: BlasFloat, INT <: CudssInt}
   cudssMatrixSetCsrPointers(matrix, A.rowPtr, CU_NULL, A.colVal, A.nzVal)
+  matrix.refs = (A.rowPtr, A.colVal, A.nzVal)
 end
 
 function cudss_update(solver::CudssSolver{T,INT}, A::CuSparseMatrixCSR{T,INT}) where {T <: BlasFloat, INT <: CudssInt}
@@ -200,6 +204,7 @@ end
 
 function cudss_update(matrix::CudssMatrix{T,INT}, rowPtr::CuVector{INT}, colVal::CuVector{INT}, nzVal::CuVector{T}) where {T <: BlasFloat, INT <: CudssInt}
   cudssMatrixSetCsrPointers(matrix, rowPtr, CU_NULL, colVal, nzVal)
+  matrix.refs = (rowPtr, colVal, nzVal)
 end
 
 function cudss_update(solver::CudssSolver{T,INT}, rowPtr::CuVector{INT}, colVal::CuVector{INT}, nzVal::CuVector{T}) where {T <: BlasFloat, INT <: CudssInt}
@@ -208,6 +213,7 @@ end
 
 function cudss_update(matrix::CudssMatrix{T,INT}, rowPtr::CuVector{INT}, colVal::CuVector{INT}, nzVal::CuMatrix{T}) where {T <: BlasFloat, INT <: CudssInt}
   cudssMatrixSetCsrPointers(matrix, rowPtr, CU_NULL, colVal, nzVal)
+  matrix.refs = (rowPtr, colVal, nzVal)
 end
 
 function cudss_update(solver::CudssSolver{T,INT}, rowPtr::CuVector{INT}, colVal::CuVector{INT}, nzVal::CuMatrix{T}) where {T <: BlasFloat, INT <: CudssInt}
@@ -219,6 +225,7 @@ function cudss_update(matrix::CudssBatchedMatrix{T}, b::Vector{<:CuVector{T}}) w
   copyto!(matrix.Mptrs, Mptrs)
   cudssMatrixSetBatchValues(matrix, matrix.Mptrs)
   unsafe_free!(Mptrs)
+  matrix.refs = b
 end
 
 function cudss_update(matrix::CudssBatchedMatrix{T}, B::Vector{<:CuMatrix{T}}) where T <: BlasFloat
@@ -226,6 +233,7 @@ function cudss_update(matrix::CudssBatchedMatrix{T}, B::Vector{<:CuMatrix{T}}) w
   copyto!(matrix.Mptrs, Mptrs)
   cudssMatrixSetBatchValues(matrix, matrix.Mptrs)
   unsafe_free!(Mptrs)
+  matrix.refs = B
 end
 
 function cudss_update(matrix::CudssBatchedMatrix{T,INT}, A::Vector{CuSparseMatrixCSR{T,INT}}) where {T <: BlasFloat, INT <: CudssInt}
@@ -237,6 +245,7 @@ function cudss_update(matrix::CudssBatchedMatrix{T,INT}, A::Vector{CuSparseMatri
   unsafe_free!(rowPtrs)
   unsafe_free!(colVals)
   unsafe_free!(nzVals)
+  matrix.refs = A
 end
 
 function cudss_update(solver::CudssBatchedSolver{T,INT}, A::Vector{CuSparseMatrixCSR{T,INT}}) where {T <: BlasFloat, INT <: CudssInt}
@@ -394,7 +403,7 @@ The available data parameters are:
 - `"info"`: Device-side error information;
 - `"lu_nnz"`: Number of non-zero entries in LU factors;
 - `"npivots"`: Number of pivots encountered during factorization;
-- `"inertia"`: Tuple of positive and negative indices of inertia for symmetric / hermitian indefinite matrices;
+- `"inertia"`: Tuple of positive and negative indices of inertia for symmetric / hermitian indefinite matrices. Note that cuDSS does not report a reliable inertia when matching is enabled (`"matching_alg"` ≠ `"default"`) -- it typically returns `(0, 0)` even though the factorization is correct, and `cudss_get` warns in that case;
 - `"perm_reorder_row"`: Reordering permutation for the rows;
 - `"perm_reorder_col"`: Reordering permutation for the columns;
 - `"perm_row"`: Final row permutation (which includes effects of both reordering and pivoting);
@@ -441,6 +450,18 @@ function cudss_get_data(solver::AbstractCudssSolver{T,INT}, parameter::String) w
     cudssDataGet(solver.data.handle, solver.data, parameter, solver.ref_int64, 8, solver.nbytes_written)
     return solver.ref_int64[]
   elseif parameter == "inertia"
+    # cuDSS (through at least 0.8) stops reporting a meaningful inertia once matching
+    # is enabled: it returns (0, 0) with info == 0 even though the factorization is
+    # correct. Downstream code that trusts the inertia (e.g. inertia-based
+    # regularization) is then silently misled, so warn loudly rather than hand back a
+    # bogus tuple. See https://github.com/exanauts/CUDSS.jl for the tracking issue.
+    if cudss_get_config(solver, "matching_alg") != cudss_algorithm("default")
+      @warn "cuDSS does not report a reliable inertia when matching is enabled " *
+            "(`matching_alg` ≠ \"default\"); it typically returns (0, 0) while the " *
+            "factorization itself is correct. Disable matching to query the inertia, " *
+            "or recover it from the factor diagonal via `cudss_set(solver, \"diag\", buf)` " *
+            "followed by `cudss_get(solver, \"diag\")`." maxlog=1
+    end
     cudssDataGet(solver.data.handle, solver.data, parameter, solver.ref_inertia, 2 * sizeof(INT), solver.nbytes_written)
     return solver.ref_inertia[]
   elseif parameter == "schur_shape"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -55,6 +55,10 @@ include("test_nonuniform_batch_cudss.jl")
     cudss_solver()
   end
 
+  @testset "Inertia under matching" begin
+    cudss_inertia_matching()
+  end
+
   @testset "CudssExecution" begin
     cudss_execution()
   end

--- a/test/test_cudss.jl
+++ b/test/test_cudss.jl
@@ -153,6 +153,39 @@ function cudss_solver()
   end
 end
 
+function cudss_inertia_matching()
+  # cuDSS (through at least 0.8) stops reporting a meaningful inertia once matching
+  # is enabled: it returns (0, 0) even though the factorization is correct. We assert
+  # the correct inertia in a `@test_broken` so the suite raises an *unexpected pass*
+  # the day cuDSS fixes it -- our nudge to drop the matching guard/warning added in
+  # `src/interfaces.jl` (`cudss_get(solver, "inertia")`).
+  n = 16
+  @testset "precision = $T" for T in (Float64, Float32)
+    INT = Cint
+    # Diagonally dominant with a positive diagonal => SPD => inertia (n, 0).
+    A_cpu = sprand(T, n, n, 0.4)
+    A_cpu = A_cpu + A_cpu' + 2n*I
+    A_gpu = CuSparseMatrixCSR{T,INT}(A_cpu)
+    x_gpu = CuVector(zeros(T, n))
+    b_gpu = CuVector(rand(T, n))
+    expected = (INT(n), INT(0))
+
+    # Baseline: without matching, cuDSS reports the correct inertia (real `@test`).
+    solver = CudssSolver(A_gpu, "S", 'F')
+    cudss("analysis", solver, x_gpu, b_gpu)
+    cudss("factorization", solver, x_gpu, b_gpu)
+    @test cudss_get(solver, "inertia") == expected
+
+    # With matching, the inertia is misreported. Marked broken -- when cuDSS starts
+    # returning `expected` here, this flips to an unexpected pass and fails the suite.
+    solver_m = CudssSolver(A_gpu, "S", 'F')
+    cudss_set(solver_m, "matching_alg", "algo1")
+    cudss("analysis", solver_m, x_gpu, b_gpu)
+    cudss("factorization", solver_m, x_gpu, b_gpu)
+    @test_broken cudss_get(solver_m, "inertia") == expected
+  end
+end
+
 function cudss_execution()
   n = 100
   p = 5


### PR DESCRIPTION
Two safety fixes surfaced while debugging GPU SCOPF solves:

1. GC-root the backing Julia arrays. CudssMatrix / CudssBatchedMatrix handed their device pointers to cuDSS but kept no reference to the arrays themselves, so a temporary could be collected while cuDSS (or a pending asynchronous phase) still held its pointer -- intermittent segfaults / EXECUTION_FAILED that look like library bugs. Add a `refs` field that keeps the arrays alive for the descriptor's lifetime, refreshed by every `cudss_update`.

2. Warn when the inertia is queried with matching enabled. cuDSS (through at least 0.8) returns inertia (0, 0) with info == 0 once `matching_alg` is set, even though the factorization is correct. Callers that trust the inertia (e.g. inertia-based regularization) are silently misled, so `cudss_get(solver, "inertia")` now emits a one-time warning in that configuration and the docstring documents the behavior.

Add `cudss_inertia_matching()` regression test: it asserts the correct inertia without matching (real `@test`) and marks the matching case `@test_broken`, so the suite raises an unexpected pass -- our nudge to drop the guard -- the day cuDSS starts reporting it correctly.