### PR TITLE
CI: skip docs deploy on Dependabot PRs

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -8,6 +8,9 @@ on:
     types: [opened, synchronize, reopened]
 jobs:
   build:
+    # Dependabot PRs run with a read-only GITHUB_TOKEN and no secrets, so the
+    # gh-pages preview push always 403s. Skip the docs deploy for those PRs.
+    if: ${{ github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Every Dependabot PR (e.g. #155) reports a failing **Documentation "Build and deploy"** job. Documenter builds the docs fine, then dies pushing the preview to `gh-pages`:

```
remote: Permission to exanauts/CUDSS.jl.git denied to github-actions[bot].
fatal: unable to access '.../CUDSS.jl.git/': The requested URL returned error: 403
```

## Cause

GitHub deliberately runs Dependabot-triggered workflows with a **read-only `GITHUB_TOKEN`** and **no access to repository secrets** (so `DOCUMENTER_KEY` is empty). With no write token and no deploy key, the `gh-pages` push always 403s. This is expected GitHub security behavior, not a bug — it started once Dependabot was enabled in #152.

## Fix

Guard the Documentation job with `if: github.actor != 'dependabot[bot]'` so it's skipped on Dependabot PRs. Real PRs and pushes to `main` carry a writable token / `DOCUMENTER_KEY` and are unaffected.